### PR TITLE
tickets/PREOPS-1236 update post transition to DP0.2

### DIFF
--- a/data-products-dp0-1/index.rst
+++ b/data-products-dp0-1/index.rst
@@ -97,8 +97,7 @@ Coadd images are divided into ``tracts`` (a spherical convex polygon) and tracts
     *"each tract is composed of 7 × 7 patches, and each patch is 4,100 × 4,100 pixels with a pixel scale of 0.2 arcsec"*.
 
 The first of the :ref:`DP0-1-Tutorials-Notebooks` demonstrates how to identify the tract and patch for a given coordinate, and retrieve and plot a coadd image.
-
-The `image display and manipulation tutorial <https://github.com/rubin-dp0/tutorial-notebooks/blob/main/03_Image_Display_and_Manipulation.ipynb>`_ demonstrates how to retrieve and display a coadd image,
+The image display and manipulation tutorial demonstrates how to retrieve and display a coadd image,
 and to use its WCS and methods associated with the image to extract a cutout image zoomed in on a region of interest.
 
 

--- a/data-products-dp0-1/index.rst
+++ b/data-products-dp0-1/index.rst
@@ -78,8 +78,6 @@ There are many associated data products that are accessible alongside PVIs. Thes
 Each PVI also has an associated mask plane that encodes quality and other information about each pixel, a WCS solution to be used in converting between pixel and sky coordinates,
 a photometric calibration object to be used in converting between fluxes and magnitudes for astronomical sources, and a model of the point-spread function (PSF) at each position on the image.
 
-To get started working with PVIs, see `this brief tutorial <https://github.com/rubin-dp0/tutorial-notebooks/blob/main/03_Image_Display_and_Manipulation.ipynb>`_ that retrieves and displays a PVI and its associated mask plane.
-
 **Coadd Images**:
 An image that is the combination of multiple input images, often referred to as just a ``coadd`` or a ``deep coadd``.
 The input images have been aligned to a common projection and pixel grid; corrected to the same photometric scale, zero-point, and point-spread function (PSF);

--- a/index.rst
+++ b/index.rst
@@ -25,7 +25,7 @@ This site provides information about the Rubin Observatory's Data Preview 0.1 (D
 **DP0.1 Release Date:** June 30, 2021
 
 .. Important::
-    The DP0.2 data set was released on June 30 2022. It is recommended that all DP0 delegates use the DP0.2 data sets. Please visit `dp0-2.lsst.io <https://dp0-2.lsst.io/>`_ for more information.
+    DP0.2 was released on June 30 2022. It is recommended that all DP0 delegates use the DP0.2 data products. Please visit `dp0-2.lsst.io <https://dp0-2.lsst.io/>`_ for more information.
 
 Data Preview 0 (DP0) is the first of three data previews during the period leading up to the start of Rubin Observatory Operations.
 The goals of DP0 are to serve as an early integration test of the Legacy Survey of Space and Time (LSST) Science Pipelines and the Rubin Science Platform (RSP),

--- a/index.rst
+++ b/index.rst
@@ -24,6 +24,9 @@ This site provides information about the Rubin Observatory's Data Preview 0.1 (D
 
 **DP0.1 Release Date:** June 30, 2021
 
+.. Important::
+    The DP0.2 data set was released on June 30 2022. It is recommended that all DP0 delegates use the DP0.2 data sets. Please visit `dp0-2.lsst.io <https://dp0-2.lsst.io/>`_ for more information.
+
 Data Preview 0 (DP0) is the first of three data previews during the period leading up to the start of Rubin Observatory Operations.
 The goals of DP0 are to serve as an early integration test of the Legacy Survey of Space and Time (LSST) Science Pipelines and the Rubin Science Platform (RSP),
 and to enable a limited number of astronomers and students to begin early preparations for science with the LSST.

--- a/tutorials-examples/index.rst
+++ b/tutorials-examples/index.rst
@@ -31,6 +31,9 @@ and :ref:`the basic components of the RSP <Data-Access-Analysis-Tools-RSP>`, and
 Jupyter notebook tutorials
 ==========================
 
+.. Important::
+    The DP0.1 notebooks are no longer supported and have been archived in the `tutorial-notebooks-dp01-archive <https://github.com/rubin-dp0/tutorial-notebooks-dp01-archive>`_ repository of the "rubin-dp0" GitHub Organization.
+
 The tutorial notebooks in the ``rubin-dp0`` GitHub Organization's `tutorial-notebooks repository <https://github.com/rubin-dp0/tutorial-notebooks>`_ will be available by default in a folder in each user's home directory in the RSP's Notebook Aspect.
 See that repository's README file for descriptions of the notebooks.
 


### PR DESCRIPTION
Changes:
 - add "DP0.2 now exists" in an Important banner to main index.html
 - add "tutorial-notebooks-dp01-archive link" in an Important banner to tutorials-examples/index.html
 - remove broken links to DP0.1-era notebooks in the DPDD page

